### PR TITLE
Updated Makefile to compile on OS X with clang

### DIFF
--- a/examples/elevator/Makefile
+++ b/examples/elevator/Makefile
@@ -62,7 +62,12 @@ LD_FLAGS     = $(CPUFLAGS)
 LD_FLAGS    += -fno-exceptions
 LD_FLAGS    += -fno-rtti
 #! LD_FLAGS += -frepo     # Enable automatic template instantiation at link time
-LD_FLAGS    += -Wl,--gc-sections
+
+ifeq ($(shell uname -s),Darwin)
+ export LD_FLAGS += -Wl,-dead_strip
+else
+ export LD_FLAGS += -Wl,--gc-sections
+endif
 
 
 .PHONY: all clean

--- a/examples/elevator/Makefile
+++ b/examples/elevator/Makefile
@@ -64,9 +64,9 @@ LD_FLAGS    += -fno-rtti
 #! LD_FLAGS += -frepo     # Enable automatic template instantiation at link time
 
 ifeq ($(shell uname -s),Darwin)
- export LD_FLAGS += -Wl,-dead_strip
+ LD_FLAGS += -Wl,-dead_strip
 else
- export LD_FLAGS += -Wl,--gc-sections
+ LD_FLAGS += -Wl,--gc-sections
 endif
 
 


### PR DESCRIPTION
Tried compiling examples:
```
$ /tinyfsm/examples/elevator make
g++ -c -I ../../include -Wa,-gdwarf-2 -MMD -Os -std=c++11 -g -fno-exceptions -fno-rtti -Wall -Wextra -Winline    -Wctor-dtor-privacy -Wcast-align -Wpointer-arith -Wredundant-decls -Wshadow -Wcast-qual -Wcast-align -pedantic -o elevator.o elevator.cpp
g++ -c -I ../../include -Wa,-gdwarf-2 -MMD -Os -std=c++11 -g -fno-exceptions -fno-rtti -Wall -Wextra -Winline    -Wctor-dtor-privacy -Wcast-align -Wpointer-arith -Wredundant-decls -Wshadow -Wcast-qual -Wcast-align -pedantic -o main.o main.cpp
g++ -c -I ../../include -Wa,-gdwarf-2 -MMD -Os -std=c++11 -g -fno-exceptions -fno-rtti -Wall -Wextra -Winline    -Wctor-dtor-privacy -Wcast-align -Wpointer-arith -Wredundant-decls -Wshadow -Wcast-qual -Wcast-align -pedantic -o motor.o motor.cpp
g++ ./elevator.o ./main.o ./motor.o  -fno-exceptions -fno-rtti -Wl,--gc-sections -o elevator
ld: unknown option: --gc-sections
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [elevator] Error 1
```

Builds fine with this fix