### PR TITLE
Add library.json for PlatformIO compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,21 @@
+{
+    "name": "tinyfsm",
+    "version": "0.3.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/digint/tinyfsm"
+    },
+    "authors": {
+        "name": "Axel Burri",
+        "email": "axel@tty0.ch",
+        "url": "http://digint.ch"
+    },
+    "license": "MIT",
+    "platforms": "*",
+    "frameworks": "*",
+    "build": {
+        "flags": [
+            "-I include/"
+        ]
+    }
+}

--- a/library.json
+++ b/library.json
@@ -1,14 +1,17 @@
 {
     "name": "tinyfsm",
+    "description": "A simple C++ finite state machine library",
     "version": "0.3.2",
     "repository": {
         "type": "git",
         "url": "https://dev.tty0.ch/tinyfsm.git"
     },
+    "homepage": "https://digint.ch/tinyfsm/",
     "authors": {
         "name": "Axel Burri",
         "email": "axel@tty0.ch",
-        "url": "http://digint.ch"
+        "url": "http://digint.ch",
+        "maintainer": true
     },
     "license": "MIT",
     "platforms": "*",

--- a/library.json
+++ b/library.json
@@ -1,9 +1,9 @@
 {
     "name": "tinyfsm",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "repository": {
         "type": "git",
-        "url": "https://github.com/digint/tinyfsm"
+        "url": "https://dev.tty0.ch/tinyfsm.git"
     },
     "authors": {
         "name": "Axel Burri",


### PR DESCRIPTION
Adds the library.json [metadata file](https://docs.platformio.org/en/latest/librarymanager/config.html) to this repository so that tinyfsm can be used in the PlatformIO build system and IDE ([website](https://docs.platformio.org/en/latest/integration/ide/pioide.html)) by means of declaring this repo [as a library dependency](https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-deps). 

PlatformIO is a versatile Python-based tool and VSCode extension that allows building for [over 800 microcontroller boards](https://platformio.org/boards) of all different architectures and frameworks like Arduino, mbed-os, Zephyr, etc. 

I've also ported the elevator example to Arduino and tested it on an Arduino Uno: https://github.com/maxgerhardt/tinyfsm-arduino-example