### PR TITLE
Add some new features and very very radical changes

### DIFF
--- a/examples/elevator/elevator.hpp
+++ b/examples/elevator/elevator.hpp
@@ -8,14 +8,14 @@
 // Event declarations
 //
 
-struct FloorEvent : tinyfsm::Event
+struct FloorEvent
 {
   int floor;
 };
 
 struct Call        : FloorEvent { };
 struct FloorSensor : FloorEvent { };
-struct Alarm       : tinyfsm::Event { };
+struct Alarm       { };
 
 
 

--- a/examples/elevator/fsmlist.hpp
+++ b/examples/elevator/fsmlist.hpp
@@ -10,9 +10,9 @@ using fsm_list = tinyfsm::FsmList<Motor, Elevator>;
 
 /** dispatch event to both "Motor" and "Elevator" */
 template<typename E>
-void send_event(E const & event)
+void send_event(E&& event)
 {
-  fsm_list::template dispatch<E>(event);
+  fsm_list::template dispatch<E>(std::forward<E>(event));
 }
 
 

--- a/examples/elevator/motor.cpp
+++ b/examples/elevator/motor.cpp
@@ -1,4 +1,3 @@
-#include <tinyfsm.hpp>
 #include "motor.hpp"
 #include <iostream>
 
@@ -7,7 +6,7 @@
 // Motor states
 //
 
-class Stopped
+struct Stopped
 : public Motor
 {
   void entry() override {
@@ -16,7 +15,7 @@ class Stopped
   };
 };
 
-class Up
+struct Up
 : public Motor
 {
   void entry() override {
@@ -25,7 +24,7 @@ class Up
   };
 };
 
-class Down
+struct Down
 : public Motor
 {
   void entry() override {

--- a/examples/elevator/motor.hpp
+++ b/examples/elevator/motor.hpp
@@ -8,9 +8,9 @@
 // Event declarations
 //
 
-struct MotorUp   : tinyfsm::Event { };
-struct MotorDown : tinyfsm::Event { };
-struct MotorStop : tinyfsm::Event { };
+struct MotorUp   {};
+struct MotorDown {};
+struct MotorStop {};
 
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This version is not fully compatible with the 0.3.2 version. The major difference is that when transit<State> is used, the compiler must be able to see the full declaration of State. In addition, the library <type_traits> and \<utility> are required.

The main functions are as follows:
1. Add a new initial entry function void initial(), just defined in the entry state
2. Add the default data transfer function during state transition.The return type of exit() can be non-null, in which case the entry must take an argument that has the same type as the return type of exit().When the transit<State> is called, the return value of the old State exit() is passed into the entry function for the new State
3. Add data transfer function during state transition.When you use Transit <State>, you can pass in a user's own data, requiring that the user's data type be the same as the entry function's argument type.
4. When FSMList dispatches events, it does not require all state machines to have the react function for the event.It is assumed that the response events of all state machines are different, that forwarding is done only once. macro TINYFSM_ENABLE_MULTIDISPATCH need to be defined to allow multiple dispatches of events

This version would have caused the existing examples to not compile and the usage documentation to be updated accordingly, so it might be better to put it in a new dev branch for now. I have modified the elevator example to be compatible with this version.
Hopefully these features will help with this project